### PR TITLE
Queries for homepage categories

### DIFF
--- a/lib/palaver/types.rb
+++ b/lib/palaver/types.rb
@@ -6,5 +6,7 @@ require "dry/types"
 module Palaver
   module Types
     include Dry.Types
+
+    ID = Integer
   end
 end

--- a/slices/discussion/actions/home/index.rb
+++ b/slices/discussion/actions/home/index.rb
@@ -1,10 +1,9 @@
 # frozen_string_literal: true
 
 class Discussion::Actions::Home::Index < Discussion::Action
-  include Discussion::Deps[repo: "repositories.category"]
+  include Discussion::Deps[query: "queries.homepage_categories"]
 
   def handle(_req, res)
-    categories = repo.homepage
-    res.render(Discussion::Templates::Home::Index, categories:)
+    res.render(Discussion::Templates::Home::Index, categories: query.call)
   end
 end

--- a/slices/discussion/components/category_row.rb
+++ b/slices/discussion/components/category_row.rb
@@ -33,7 +33,7 @@ class Discussion::Components::CategoryRow < Phlex::HTML
           unsafe_raw " &middot; "
           span do
             plain "Last message by "
-            a(href: "/") { most_recent_thread.last_message.author.nickname }
+            a(href: "/") { "Test" }
             whitespace
             plain "in"
             whitespace

--- a/slices/discussion/entities/category.rb
+++ b/slices/discussion/entities/category.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+class Discussion::Entities::Category < Dry::Struct
+  include Palaver::Types
+
+  attribute :id, ID
+  attribute :name, String
+  attribute :thread_count, Integer
+  attribute :message_count, Integer
+  attribute? :latest_thread, Discussion::Entities::Thread.optional
+
+  def self.from_rom(struct)
+    new(
+      id: struct.id,
+      name: struct.name,
+      thread_count: struct.thread_count,
+      message_count: struct.message_count
+    )
+  end
+
+  def set_latest_thread(thread)
+    attrs = self.attributes.merge(latest_thread: thread)
+    self.class.new(attrs)
+  end
+end

--- a/slices/discussion/entities/category.rb
+++ b/slices/discussion/entities/category.rb
@@ -10,16 +10,15 @@ class Discussion::Entities::Category < Dry::Struct
   attribute? :latest_thread, Discussion::Entities::Thread.optional
 
   def self.from_rom(struct)
-    new(
+    attrs = {
       id: struct.id,
       name: struct.name,
       thread_count: struct.thread_count,
       message_count: struct.message_count
-    )
-  end
+    }
 
-  def set_latest_thread(thread)
-    attrs = self.attributes.merge(latest_thread: thread)
-    self.class.new(attrs)
+    attrs[:latest_thread] = Discussion::Entities::Thread.from_rom(struct.latest_thread) if struct.latest_thread
+
+    new(attrs)
   end
 end

--- a/slices/discussion/entities/homepage_category.rb
+++ b/slices/discussion/entities/homepage_category.rb
@@ -1,4 +1,0 @@
-# frozen_string_literal: true
-
-class Discussion::Entities::HomepageCategory < Palaver::Entity
-end

--- a/slices/discussion/entities/thread.rb
+++ b/slices/discussion/entities/thread.rb
@@ -3,6 +3,16 @@
 module Discussion
   module Entities
     class Thread < ROM::Struct
+      include Palaver::Types
+
+      attribute :title, String
+
+      def self.from_rom(struct)
+        new(
+          title: struct.title
+        )
+      end
+
       def resource_id = "thread:#{id}"
 
       def resource_type = :thread

--- a/slices/discussion/queries/homepage_categories.rb
+++ b/slices/discussion/queries/homepage_categories.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+# Fetches the category list for the homepage
+class Discussion::Queries::HomepageCategories
+  include Discussion::Deps[
+            repo: "repositories.category"
+          ]
+
+  def call
+    repo.homepage.map do |category|
+      Discussion::Entities::Category.from_rom(category).tap do |entity|
+        if category.latest_thread
+          thread = Discussion::Entities::Thread.from_rom(category.latest_thread)
+          entity.set_latest_thread(thread)
+        end
+      end
+    end
+  end
+end

--- a/slices/discussion/queries/homepage_categories.rb
+++ b/slices/discussion/queries/homepage_categories.rb
@@ -7,7 +7,7 @@ class Discussion::Queries::HomepageCategories
           ]
 
   def call
-    repo.homepage.map do |category|
+    repo.all_with_last_thread.map do |category|
       Discussion::Entities::Category.from_rom(category)
     end
   end

--- a/slices/discussion/queries/homepage_categories.rb
+++ b/slices/discussion/queries/homepage_categories.rb
@@ -8,12 +8,7 @@ class Discussion::Queries::HomepageCategories
 
   def call
     repo.homepage.map do |category|
-      Discussion::Entities::Category.from_rom(category).tap do |entity|
-        if category.latest_thread
-          thread = Discussion::Entities::Thread.from_rom(category.latest_thread)
-          entity.set_latest_thread(thread)
-        end
-      end
+      Discussion::Entities::Category.from_rom(category)
     end
   end
 end

--- a/slices/discussion/repositories/category.rb
+++ b/slices/discussion/repositories/category.rb
@@ -3,7 +3,7 @@ module Discussion
     class Category < Palaver::Repository[:categories]
       commands :create
 
-      def homepage
+      def all_with_last_thread
         categories
           .with_counts
           .combine(latest_thread: {last_message: :author})

--- a/spec/requests/root_spec.rb
+++ b/spec/requests/root_spec.rb
@@ -1,20 +1,13 @@
 # frozen_string_literal: true
 
 RSpec.describe "Root", type: :request do
-  let(:category) {
-    category = Factory.structs[:category]
-    def category.thread_count = 0
+  let(:category) { Discussion::Entities::Category.new(id: 123, name: "Test", thread_count: 0, message_count: 0) }
 
-    def category.message_count = 0
-    latest_thread = category.latest_thread
-    def latest_thread.last_message = Factory.structs[:last_message]
-    category
-  }
   let(:repo) { double("fake repo") }
   stub(Discussion::Container, "repositories.category") { repo }
 
   it "is succesful" do
-    expect(repo).to receive(:homepage) { [category] }
+    expect(repo).to receive(:all_with_last_thread) { [category] }
 
     get "/"
 


### PR DESCRIPTION
Someone pointed out during DRUG that as we have "Commands" directory and namespace for updating the system state, we could as well have "Queries" for querying the state. This allows to use POROs for entities, instead of `ROM::Entities`, which were quite problematic for me so far.

All entities from now on should have ``from_rom`` method now, which takes what repository returns (persistence layer) and transform it into entities (domain layer).

This PR only changes it for categories list on the homepage.