### PR TITLE
Add slugs to categories and threads

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -1,2 +1,3 @@
 DATABASE_URL=postgres://localhost/palaver_test
 SECRET=test
+HASHIDS_SALT=this_is_the_salt

--- a/Gemfile
+++ b/Gemfile
@@ -21,6 +21,8 @@ gem "rom-sql", "~> 3.6.0"
 gem "shrine", "~> 3.0"
 gem "shrine-rom"
 gem "verifica"
+gem "hashids"
+gem "stringex"
 
 group :cli, :development do
   gem "hanami-reloader"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -148,6 +148,7 @@ GEM
       dry-validation (>= 1.10, < 2)
       zeitwerk (~> 2.6.0)
     hansi (0.2.1)
+    hashids (1.0.6)
     i18n (1.13.0)
       concurrent-ruby (~> 1.0)
     ice_nine (0.11.2)
@@ -281,6 +282,7 @@ GEM
     standard-performance (1.0.1)
       lint_roller (~> 1.0)
       rubocop-performance (~> 1.16.0)
+    stringex (2.8.6)
     thor (1.2.1)
     transproc (1.1.1)
     unicode-display_width (2.4.2)
@@ -305,6 +307,7 @@ DEPENDENCIES
   hanami-rspec
   hanami-utils (~> 2.0.0)
   hanami-validations (~> 2.0.0)
+  hashids
   nokolexbor
   pg
   phlex (~> 1.6)
@@ -318,6 +321,7 @@ DEPENDENCIES
   shrine-rom
   simplecov
   standard
+  stringex
   verifica
 
 BUNDLED WITH

--- a/slices/discussion/actions/category/show.rb
+++ b/slices/discussion/actions/category/show.rb
@@ -3,11 +3,13 @@
 class Discussion::Actions::Category::Show < Discussion::Action
   include Discussion::Deps[
     repo: "repositories.category",
-    threads_repo: "repositories.thread"
+    threads_repo: "repositories.thread",
+    slugger: "utils.slugger"
   ]
 
   def handle(req, res)
-    category = repo.get(req.params[:id])
+    id = slugger.decode_id(req.params[:id])
+    category = repo.get(id)
     threads = threads_repo.by_category(category.id)
     res.render(Discussion::Templates::Category::Show, category: category, threads: threads)
   end

--- a/slices/discussion/actions/thread/show.rb
+++ b/slices/discussion/actions/thread/show.rb
@@ -2,12 +2,14 @@
 
 class Discussion::Actions::Thread::Show < Discussion::Action
   include Discussion::Deps[
-            repo: "repositories.thread"
+    repo: "repositories.thread",
+    slugger: "utils.slugger"
           ]
 
   def handle(req, res)
+    id = slugger.decode_id(req.params[:id])
     page = req.params[:page] || 1
-    thread = repo.get(req.params[:id])
+    thread = repo.get(id)
     pager = repo.paged_messages(thread.id, page.to_i)
     res.render(Discussion::Templates::Thread::Show, thread:, pager:)
   end

--- a/slices/discussion/components/category_row.rb
+++ b/slices/discussion/components/category_row.rb
@@ -1,4 +1,6 @@
 class Discussion::Components::CategoryRow < Phlex::HTML
+  include Discussion::Deps["utils.slugger"]
+
   class Detail < Phlex::HTML
     def initialize(label, value)
       @label = label
@@ -15,14 +17,17 @@ class Discussion::Components::CategoryRow < Phlex::HTML
 
   attr_reader :category
 
-  def initialize(category:)
+  def initialize(category:, slugger:)
     @category = category
+    @slugger = slugger
   end
 
   def template
+    slug = @slugger.to_slug(Discussion::Entities::Category::HASHIDS_NUM, category.name, category.id)
+
     article(class: "category mb-5") do
       h4(class: "is-size-4") do
-        a(href: "/cat/#{category.id}") { category.name }
+        a(href: "/cat/#{slug}") { category.name }
       end
 
       div do

--- a/slices/discussion/components/thread_row.rb
+++ b/slices/discussion/components/thread_row.rb
@@ -1,9 +1,14 @@
 class Discussion::Components::ThreadRow < Phlex::HTML
-  def initialize(thread)
+  include Discussion::Deps["utils.slugger"]
+
+  def initialize(thread, slugger:)
     @thread = thread
+    @slugger = slugger
   end
 
   def template
+    slug = @slugger.to_slug(Discussion::Entities::Thread::HASHIDS_NUM, @thread.title, @thread.id)
+
     article(class: "mt-5 mb-5 media thread-row") do
       figure(class: "media-left") do
         p(class: "image is-64x64") do
@@ -13,7 +18,7 @@ class Discussion::Components::ThreadRow < Phlex::HTML
       div(class: "media-content") do
         div(class: "content") do
           h4(class: "is-size-4") do
-            a(href: "/th/#{@thread.id}") { @thread.title }
+            a(href: "/th/#{slug}") { @thread.title }
             span(class: "ml-2 tag is-info is-light") { "Pinned" } if @thread.pinned
           end
         end

--- a/slices/discussion/entities/category.rb
+++ b/slices/discussion/entities/category.rb
@@ -1,7 +1,12 @@
 # frozen_string_literal: true
 
+require "stringex/unidecoder"
+require "hashids"
+
 class Discussion::Entities::Category < Dry::Struct
   include Palaver::Types
+
+  HASHIDS_NUM = 1
 
   attribute :id, ID
   attribute :name, String

--- a/slices/discussion/entities/thread.rb
+++ b/slices/discussion/entities/thread.rb
@@ -1,9 +1,13 @@
 # frozen_string_literal: true
 
+require "hashids"
+
 module Discussion
   module Entities
     class Thread < ROM::Struct
       include Palaver::Types
+
+      HASHIDS_NUM = 2
 
       attribute :title, String
       attribute :id, Integer

--- a/slices/discussion/utils/slug_provider.rb
+++ b/slices/discussion/utils/slug_provider.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require "stringex"
+
+module Discussion
+  module Utils
+    # This is a code that actually creates a slugged value from a string.
+    # It uses Stringex, which is great, but it's also slow. That's why it's being put into
+    # a separate class, so we may replace in with something simpler yet efficient in tests.
+    class SlugProvider
+      def call(string)
+        string.to_url
+      end
+    end
+  end
+end

--- a/slices/discussion/utils/slugger.rb
+++ b/slices/discussion/utils/slugger.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require "hashids"
+
+module Discussion
+  module Utils
+    class Slugger
+      include Deps["utils.slug_provider"]
+
+      def to_slug(num, string, id)
+        hashids = Hashids.new(ENV["HASHIDS_SALT"])
+        hash = hashids.encode(num, id)
+        "#{slug_provider.call(string)}-#{hash}"
+      end
+
+      def decode_id(slug)
+        hashids = Hashids.new(ENV["HASHIDS_SALT"])
+        hashid = slug.split("-").last
+        _num, id = hashids.decode(hashid)
+        id
+      end
+    end
+  end
+end

--- a/spec/requests/discussion/categories/show_spec.rb
+++ b/spec/requests/discussion/categories/show_spec.rb
@@ -5,7 +5,9 @@ RSpec.describe "GET /cat/:id", type: :request do
 
   specify "with no threads" do
     category = repo.create(name: "abcd")
-    get "/cat/#{category.id}"
+    slug = category_slug(category)
+
+    get "/cat/#{slug}"
 
     expect(last_response).to be_successful
     expect(last_response.body).to include("No threads")
@@ -15,7 +17,9 @@ RSpec.describe "GET /cat/:id", type: :request do
     category = repo.create(name: "abcd")
     thread_repo.create(title: "A test thread", content: "Testiiiing",
       category_id: category.id, author: author)
-    get "/cat/#{category.id}"
+    slug = category_slug(category)
+
+    get "/cat/#{slug}"
 
     expect(last_response).to be_successful
     expect(last_response.body).not_to include("No threads")

--- a/spec/requests/discussion/threads/show_spec.rb
+++ b/spec/requests/discussion/threads/show_spec.rb
@@ -9,13 +9,13 @@ RSpec.describe "GET /th/:id", type: :request do
 
   describe "as anonymous user" do
     specify "shows title and first message" do
-      get "/th/#{thread.id}"
+      get "/th/#{thread_slug(thread)}"
       expect(last_response.body).to include("A test thread")
       expect(last_response.body).to include("Testing")
     end
 
     specify "does not display reply form" do
-      get "/th/#{thread.id}"
+      get "/th/#{thread_slug(thread)}"
       expect(last_response.body).not_to include("Write your reply")
     end
   end
@@ -23,7 +23,7 @@ RSpec.describe "GET /th/:id", type: :request do
   describe "as a signed in user without profile set up" do
     specify "does not display reply form" do
       env "rack.session", {usi: user.id}
-      get "/th/#{thread.id}"
+      get "/th/#{thread_slug(thread)}"
 
       expect(last_response.body).not_to include("Write your reply")
       expect(last_response.body).to include("You need to set up your profile to start posting")
@@ -34,7 +34,7 @@ RSpec.describe "GET /th/:id", type: :request do
     specify "displays reply form" do
       Discussion::Container["repositories.profile"].create(nickname: "Joshua", account_id: user.id)
       env "rack.session", {usi: user.id}
-      get "/th/#{thread.id}"
+      get "/th/#{thread_slug(thread)}"
 
       expect(last_response.body).to include("Write your reply")
     end

--- a/spec/slices/discussion/actions/category/show_spec.rb
+++ b/spec/slices/discussion/actions/category/show_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Discussion::Actions::Category::Show do
       category = Factory.structs[:category]
       expect(repo).to receive(:get) { category }
 
-      response = action.call({id: category.id})
+      response = action.call({id: category_slug(category)})
       expect(response.body.first).to include("No threads")
     end
   end

--- a/spec/slices/discussion/utils/slugger_spec.rb
+++ b/spec/slices/discussion/utils/slugger_spec.rb
@@ -1,0 +1,15 @@
+RSpec.describe Discussion::Utils::Slugger do
+  subject(:slugger) { described_class.new }
+
+  it "decodes the id in slug to the same id" do
+    id = rand(15_000)
+    slug = slugger.to_slug(5, "abc", id)
+    decoded_id = slugger.decode_id(slug)
+    expect(decoded_id).to eq(id)
+  end
+
+  it "contains downcased name in the slug" do
+    slug = slugger.to_slug(5, "The Big THING", 42)
+    expect(slug).to include("the-big-thing")
+  end
+end

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -1,7 +1,19 @@
 module RSpecHelpers
-  def stub(container, key, &block)
-    around :each do |example|
-      container.stub(key, instance_exec(&block)) { example.run }
+  module ClassMethods
+    def stub(container, key, &block)
+      around :each do |example|
+        container.stub(key, instance_exec(&block)) { example.run }
+      end
+    end
+  end
+
+  module InstanceMethods
+    def category_slug(category)
+      Discussion::Utils::Slugger.new.to_slug(Discussion::Entities::Category::HASHIDS_NUM, category.name, category.id)
+    end
+
+    def thread_slug(thread)
+      Discussion::Utils::Slugger.new.to_slug(Discussion::Entities::Thread::HASHIDS_NUM, thread.title, thread.id)
     end
   end
 end

--- a/spec/support/rspec.rb
+++ b/spec/support/rspec.rb
@@ -5,7 +5,8 @@ require_relative "fixtures/account"
 require_relative "fixtures/discussion"
 
 RSpec.configure do |config|
-  config.extend RSpecHelpers
+  config.extend RSpecHelpers::ClassMethods
+  config.include RSpecHelpers::InstanceMethods
 
   config.expect_with :rspec do |expectations|
     expectations.include_chain_clauses_in_custom_matcher_descriptions = true

--- a/spec/support/rspec.rb
+++ b/spec/support/rspec.rb
@@ -35,5 +35,6 @@ RSpec.configure do |config|
   config.before(:all) do
     require "argon2"
     Account::Container.stub("utils.hasher", Argon2::Password.new(t_cost: 1, m_cost: 4, p_cost: 1))
+    Discussion::Container.stub("utils.slug_provider", ->(string) { string.downcase.tr(" ", "-") })
   end
 end


### PR DESCRIPTION
This PR add support for using readable slugs instead of numerical ids for categories and threads. It uses Stringex and Hashids to create a slug. The last part of the slug is a Hashids-encoded id, so the slugs are created dynamically, not stored in the database.

Because Stringex is very slow to load (> 2 seconds), in tests it's stubbed out with a basic inaccurate version. This way tests are still pretty fast.