### PR TITLE
Add query to get threads in category

### DIFF
--- a/slices/discussion/actions/category/show.rb
+++ b/slices/discussion/actions/category/show.rb
@@ -3,14 +3,14 @@
 class Discussion::Actions::Category::Show < Discussion::Action
   include Discussion::Deps[
     repo: "repositories.category",
-    threads_repo: "repositories.thread",
-    slugger: "utils.slugger"
+    slugger: "utils.slugger",
+    query: "queries.threads_in_category"
   ]
 
   def handle(req, res)
     id = slugger.decode_id(req.params[:id])
     category = repo.get(id)
-    threads = threads_repo.by_category(category.id)
+    threads = query.call(category.id)
     res.render(Discussion::Templates::Category::Show, category: category, threads: threads)
   end
 end

--- a/slices/discussion/entities/thread.rb
+++ b/slices/discussion/entities/thread.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "hashids"
-
 module Discussion
   module Entities
     class Thread < ROM::Struct
@@ -11,10 +9,15 @@ module Discussion
 
       attribute :title, String
       attribute :id, Integer
+      attribute? :pinned, Bool
+      attribute? :messages, Array
 
       def self.from_rom(struct)
         new(
-          title: struct.title
+          id: struct.id,
+          title: struct.title,
+          pinned: struct.pinned,
+          messages: struct.messages
         )
       end
 

--- a/slices/discussion/queries/homepage_categories.rb
+++ b/slices/discussion/queries/homepage_categories.rb
@@ -2,9 +2,7 @@
 
 # Fetches the category list for the homepage
 class Discussion::Queries::HomepageCategories
-  include Discussion::Deps[
-            repo: "repositories.category"
-          ]
+  include Discussion::Deps[repo: "repositories.category"]
 
   def call
     repo.all_with_last_thread.map do |category|

--- a/slices/discussion/queries/threads_in_category.rb
+++ b/slices/discussion/queries/threads_in_category.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Discussion
+  module Queries
+    class ThreadsInCategory
+      include Discussion::Deps[repo: "repositories.thread"]
+
+      def call(category_id)
+        repo.by_category(category_id).map do |thread|
+          Discussion::Entities::Thread.from_rom(thread)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Instead of calling thread repo directly, use a query object that handles the transformation from the `ROM::Struct` into a proper entity. We cannot yet transform `Discussion::Entities::Threads` into a `Dry::Struct`, but it's a good first step.

Some unanswered questions:
* Is a thread on a list in a category view the same entity as a thread in a thread view?