### PR TITLE
New account settings page

### DIFF
--- a/lib/ui/components/columns.rb
+++ b/lib/ui/components/columns.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Ui
+  module Components
+    class Columns < Phlex::HTML
+      def template(&)
+        div(class: "columns", &)
+      end
+
+      def column(&)
+        div(class: "column", &)
+      end
+    end
+  end
+end

--- a/lib/ui/components/form.rb
+++ b/lib/ui/components/form.rb
@@ -3,6 +3,7 @@
 module Ui
   module Components
     class Form < Phlex::HTML
+      include Ui::Form
       attr_reader :url
 
       def initialize(url:, multipart: false)
@@ -14,6 +15,11 @@ module Ui
         params = {method: "POST", action: url}
         params[:enctype] = "multipart/form-data" if @multipart
         form(**params, &content)
+      end
+
+      def section_title(title, pad_top: false)
+        extra_classes = pad_top ? " pt-5" : ""
+        h4(class: "is-size-4 pb-2 mb-2#{extra_classes}") { title }
       end
     end
   end

--- a/lib/ui/components/form/field.rb
+++ b/lib/ui/components/form/field.rb
@@ -5,13 +5,14 @@ class Ui::Components::Form::Field < Phlex::HTML
 
   # NOTE: We are not creating a getter fot label, because it conflicts with label method
   # from Phlex
-  def initialize(label:, name:, type: :text, placeholder: nil, value: nil, error: nil)
+  def initialize(label:, name:, type: :text, placeholder: nil, value: nil, error: nil, disabled: false)
     @type = type
     @label = label
     @name = name
     @placeholder = placeholder
     @value = value
     @error = error
+    @disabled = disabled
   end
 
   def template
@@ -23,7 +24,7 @@ class Ui::Components::Form::Field < Phlex::HTML
 
   private
 
-  def render_input
+  def render_input(disabled: false)
     classes = ["input", @error.nil? ? nil : "is-danger"].compact.join(" ")
     case type
     when :textarea
@@ -40,7 +41,7 @@ class Ui::Components::Form::Field < Phlex::HTML
         end
       end
     else
-      input(class: classes, name: name, type: type.to_s, placeholder: placeholder, value: value)
+      input(class: classes, name: name, type: type.to_s, placeholder: placeholder, value: value, disabled: disabled)
     end
   end
 end

--- a/lib/ui/components/form/horizontal_field.rb
+++ b/lib/ui/components/form/horizontal_field.rb
@@ -9,7 +9,7 @@ class Ui::Components::Form::HorizontalField < Ui::Components::Form::Field
       div(class: "field-body") do
         div(class: "field") do
           p(class: "control is-expanded") do
-            render_input
+            render_input(disabled: @disabled)
           end
           if @error
             p(class: "help is-danger") { @error.join(", ") }

--- a/lib/ui/form.rb
+++ b/lib/ui/form.rb
@@ -4,8 +4,16 @@ module Ui
       input(name: name, value: value, type: "hidden")
     end
 
-    def horizontal_field(label:, name:, placeholder: "", type: "text", value: nil, error: nil)
-      render Ui::Components::Form::HorizontalField.new(label:, name:, placeholder:, type:, value:, error:)
+    def horizontal_field(label:, name:, placeholder: "", type: "text", value: nil, error: nil, disabled: false)
+      render Ui::Components::Form::HorizontalField.new(label:, name:, placeholder:, type:, value:, error:, disabled:)
+    end
+
+    def submit(label)
+      render Ui::Components::Form::HorizontalSubmit.new(label:)
+    end
+
+    def csrf(token)
+      hidden_field("_csrf_token", token)
     end
 
     def field_info

--- a/lib/ui/layout.rb
+++ b/lib/ui/layout.rb
@@ -28,6 +28,7 @@ module Ui
                     div(class: "navbar-item has-dropdown is-hoverable") do
                       a(class: "navbar-link") { current_user.email }
                       div(class: "navbar-dropdown") do
+                        a(class: "navbar-item", href: "/account/settings") { "Account settings" }
                         a(class: "navbar-item", href: "/profile") { "My Profile" }
                         a(class: "navbar-item", href: "/account/sign_out") { "Sign out" }
                       end

--- a/slices/account/actions/settings/save.rb
+++ b/slices/account/actions/settings/save.rb
@@ -1,13 +1,13 @@
 # frozen_string_literal: true
 
-require 'argon2'
+require "argon2"
 require "dry/monads"
 require "dry/monads/do"
-require 'hanami/utils/blank'
+require "hanami/utils/blank"
 
 class Account::Actions::Settings::Save < Account::Action
   include Account::Deps[fetch_settings: "queries.settings", change_password: "commands.change_password",
-                        set_avatar: "commands.set_avatar"]
+    set_avatar: "commands.set_avatar"]
 
   require_signed_in_user!
 
@@ -27,7 +27,7 @@ class Account::Actions::Settings::Save < Account::Action
   def handle(req, res)
     current_user = res[:current_user]
 
-    result = Dry::Monads::Do.() do
+    result = Dry::Monads::Do.call do
       Dry::Monads::Do.bind validate_params(req)
       Dry::Monads::Do.bind verify_current_password(current_user, req) if param_present?(req, :new_password) || param_present?(req, :current_password)
       Dry::Monads::Do.bind change_password.call(current_user.id, req.params[:new_password]) if param_present?(req, :new_password)

--- a/slices/account/actions/settings/save.rb
+++ b/slices/account/actions/settings/save.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require 'argon2'
+require "dry/monads/do"
+
+class Account::Actions::Settings::Save < Account::Action
+  include Account::Deps[fetch_settings: "queries.settings"]
+
+  require_signed_in_user!
+
+  contract do
+    params do
+      optional(:current_password).maybe(:string)
+      optional(:new_password).maybe(:string, min_size?: 8)
+      optional(:new_password_confirmation).maybe(:string, min_size?: 8)
+      optional(:avatar)
+    end
+
+    rule(:new_password_confirmation, :new_password) do
+      key.failure("passwords do not match") if values[:new_password] != values[:new_password_confirmation]
+    end
+  end
+
+  def handle(req, res)
+    current_user = res[:current_user]
+
+    result = Dry::Monads::Do.() do
+      Dry::Monads::Do.bind validate_params(req)
+      Dry::Monads::Do.bind verify_current_password(current_user, req)
+      Success()
+    end
+
+    case result
+    when Failure(:invalid_params)
+      render_show(req, res)
+    when Failure(:current_password_invalid)
+      req.params.errors[:current_password] = ["incorrect password"]
+      render_show(req, res)
+    when Success()
+      res.flash[:success] = "Settings saved."
+      res.redirect_to "/account/settings"
+    end
+  end
+
+  private
+
+  def render_show(req, res)
+    current_user = res[:current_user]
+    settings = fetch_settings.call(current_user.id)
+    res.render(Account::Templates::Settings::Show, settings:, errors: req.params.errors, values: req.params.to_h)
+  end
+
+  def verify_current_password(account, req)
+    if Argon2::Password.verify_password(req.params[:current_password], account.password_hash)
+      Success()
+    else
+      Failure(:current_password_invalid)
+    end
+  end
+end

--- a/slices/account/actions/settings/save.rb
+++ b/slices/account/actions/settings/save.rb
@@ -1,10 +1,11 @@
 # frozen_string_literal: true
 
 require 'argon2'
+require "dry/monads"
 require "dry/monads/do"
 
 class Account::Actions::Settings::Save < Account::Action
-  include Account::Deps[fetch_settings: "queries.settings"]
+  include Account::Deps[fetch_settings: "queries.settings", change_password: "commands.change_password"]
 
   require_signed_in_user!
 
@@ -27,6 +28,7 @@ class Account::Actions::Settings::Save < Account::Action
     result = Dry::Monads::Do.() do
       Dry::Monads::Do.bind validate_params(req)
       Dry::Monads::Do.bind verify_current_password(current_user, req)
+      Dry::Monads::Do.bind change_password.call(current_user.id, req.params[:new_password]) if req.params[:new_password]
       Success()
     end
 

--- a/slices/account/actions/settings/show.rb
+++ b/slices/account/actions/settings/show.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class Account::Actions::Settings::Show < Account::Action
+  include Account::Deps[fetch_settings: "queries.settings"]
+
+  require_signed_in_user!
+
+  def handle(req, res)
+    settings = fetch_settings.call(res[:current_user].id)
+    res.render(Account::Templates::Settings::Show, settings:, errors: {}, values: {})
+  end
+end

--- a/slices/account/commands/change_password.rb
+++ b/slices/account/commands/change_password.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require "dry/monads"
+
+class Account::Commands::ChangePassword
+  include Dry::Monads[:result]
+  include Account::Deps[repo: "repositories.account", hasher: "utils.hasher"]
+
+  def call(user_id, password)
+    password_hash = hasher.create(password)
+    account = repo.update(user_id, password_hash:)
+    Success(account)
+  end
+end

--- a/slices/account/commands/register_user.rb
+++ b/slices/account/commands/register_user.rb
@@ -1,4 +1,5 @@
 require "argon2"
+require "dry/monads"
 
 class Account::Commands::RegisterUser
   include Dry::Monads[:result]

--- a/slices/account/commands/set_avatar.rb
+++ b/slices/account/commands/set_avatar.rb
@@ -7,7 +7,7 @@ class Account::Commands::SetAvatar
   include Account::Deps[repo: "repositories.profile"]
 
   def call(user_id, avatar)
-    attacher = Discussion::Entities::Profile.avatar_attacher
+    attacher = Account::Entities::Settings.avatar_attacher
     attacher.assign(avatar)
     attacher.finalize
 

--- a/slices/account/commands/set_avatar.rb
+++ b/slices/account/commands/set_avatar.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require "dry/monads"
+
+class Account::Commands::SetAvatar
+  include Dry::Monads[:result]
+  include Account::Deps[repo: "repositories.profile"]
+
+  def call(user_id, avatar)
+    attacher = Discussion::Entities::Profile.avatar_attacher
+    attacher.assign(avatar)
+    attacher.finalize
+
+    params = {avatar_data: attacher.column_data}
+    profile = repo.by_account_id(user_id)
+    profile = repo.update(profile.id, params)
+    Success(profile)
+  end
+end

--- a/slices/account/config/routes.rb
+++ b/slices/account/config/routes.rb
@@ -7,5 +7,8 @@ module Account
     get "/sign_in", to: "sign_in.new"
     post "/sign_in", to: "sign_in.create"
     get "/sign_out", to: "sign_in.destroy"
+
+    get "/settings", to: "settings.show"
+    post "/settings", to: "settings.save"
   end
 end

--- a/slices/account/entities/settings.rb
+++ b/slices/account/entities/settings.rb
@@ -2,16 +2,19 @@
 
 class Account::Entities::Settings < ROM::Struct
   include Palaver::Types
+  include Palaver::AvatarUploader::Attachment(:avatar)
 
   attribute :user_id, Integer
   attribute :email, String
   attribute :nickname, String
+  attribute :avatar_data, String.optional
 
   def self.from_rom(user)
     new(
       user_id: user.id,
       email: user.email,
-      nickname: user.profile.nickname
+      nickname: user.profile.nickname,
+      avatar_data: user.profile.avatar_data
     )
   end
 end

--- a/slices/account/entities/settings.rb
+++ b/slices/account/entities/settings.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class Account::Entities::Settings < ROM::Struct
+  include Palaver::Types
+
+  attribute :user_id, Integer
+  attribute :email, String
+  attribute :nickname, String
+
+  def self.from_rom(user)
+    new(
+      user_id: user.id,
+      email: user.email,
+      nickname: user.profile.nickname
+    )
+  end
+end

--- a/slices/account/queries/settings.rb
+++ b/slices/account/queries/settings.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module Account
+  module Queries
+    class Settings
+      include Account::Deps[repo: "repositories.account"]
+
+      def call(user_id)
+        settings = repo.settings_for_user(user_id)
+        Account::Entities::Settings.from_rom(settings)
+      end
+    end
+  end
+end

--- a/slices/account/repositories/account.rb
+++ b/slices/account/repositories/account.rb
@@ -18,4 +18,8 @@ class Account::Repositories::Account < Palaver::Repository[:accounts]
   def by_session_id(id)
     accounts.by_pk(id).map_to(Account::Entities::CurrentUser).one || Account::Entities::AnonymousUser.new
   end
+
+  def settings_for_user(id)
+    accounts.by_pk(id).combine(:profile).one
+  end
 end

--- a/slices/account/repositories/account.rb
+++ b/slices/account/repositories/account.rb
@@ -1,7 +1,11 @@
 class Account::Repositories::Account < Palaver::Repository[:accounts]
   struct_namespace Account::Entities
   auto_struct true
-  commands :create
+  commands :create, update: :by_pk
+
+  def by_id(id)
+    accounts.where(id:).one!
+  end
 
   def by_id_and_token(id, token)
     accounts.where(id: id, confirmation_token: token).one

--- a/slices/account/repositories/profile.rb
+++ b/slices/account/repositories/profile.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class Account::Repositories::Profile < Palaver::Repository[:profiles]
+  commands update: :by_pk
+
+  def by_account_id(id)
+    profiles.where(account_id: id).one!
+  end
+end

--- a/slices/account/templates/settings/show.rb
+++ b/slices/account/templates/settings/show.rb
@@ -14,15 +14,22 @@ class Account::Templates::Settings::Show < Palaver::View
 
           form.section_title("Password reset", pad_top: true)
           form.horizontal_field(label: "Current password", name: "current_password", type: :password,
-                                error: @errors[:current_password], value: @values[:current_password])
+            error: @errors[:current_password], value: @values[:current_password])
           form.horizontal_field(label: "New password", name: "new_password", type: :password,
-                                error: @errors[:new_password], value: @values[:new_password])
+            error: @errors[:new_password], value: @values[:new_password])
           form.horizontal_field(label: "Confirm new password", name: "new_password_confirmation", type: :password,
-                                error: @errors[:new_password_confirmation], value: @values[:new_password_confirmation])
+            error: @errors[:new_password_confirmation], value: @values[:new_password_confirmation])
         end
 
         columns.column do
           form.section_title("Avatar")
+
+          if @settings.avatar_data
+            p(class: "image is-128x128 mb-3 mt-3") do
+              img(src: @settings.avatar.url)
+            end
+          end
+
           form.input(type: "hidden", value: nil, name: :avatar)
           form.horizontal_field(label: "Pick new", name: :avatar, type: :file)
         end

--- a/slices/account/templates/settings/show.rb
+++ b/slices/account/templates/settings/show.rb
@@ -5,7 +5,7 @@ class Account::Templates::Settings::Show < Palaver::View
 
   def template
     heading2("Account settings")
-    render Ui::Components::Form.new(url: "/account/settings") do |form|
+    render Ui::Components::Form.new(url: "/account/settings", multipart: true) do |form|
       form.csrf(csrf_token)
       render Ui::Components::Columns.new do |columns|
         columns.column do

--- a/slices/account/templates/settings/show.rb
+++ b/slices/account/templates/settings/show.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+class Account::Templates::Settings::Show < Palaver::View
+  include Ui::Typography
+
+  def template
+    heading2("Account settings")
+    render Ui::Components::Form.new(url: "/account/settings") do |form|
+      form.csrf(csrf_token)
+      render Ui::Components::Columns.new do |columns|
+        columns.column do
+          form.horizontal_field(label: "Email", name: "email", value: @settings.email, disabled: true)
+          form.horizontal_field(label: "Name", name: "name", value: @settings.nickname, disabled: true)
+
+          form.section_title("Password reset", pad_top: true)
+          form.horizontal_field(label: "Current password", name: "current_password", type: :password,
+                                error: @errors[:current_password], value: @values[:current_password])
+          form.horizontal_field(label: "New password", name: "new_password", type: :password,
+                                error: @errors[:new_password], value: @values[:new_password])
+          form.horizontal_field(label: "Confirm new password", name: "new_password_confirmation", type: :password,
+                                error: @errors[:new_password_confirmation], value: @values[:new_password_confirmation])
+        end
+
+        columns.column do
+          form.section_title("Avatar")
+          form.input(type: "hidden", value: nil, name: :avatar)
+          form.horizontal_field(label: "Pick new", name: :avatar, type: :file)
+        end
+      end
+
+      div(class: "is-flex is-justify-content-center pt-4") do
+        form.submit("Save changes")
+      end
+    end
+  end
+end

--- a/spec/requests/account/registration/create_spec.rb
+++ b/spec/requests/account/registration/create_spec.rb
@@ -76,9 +76,12 @@ RSpec.describe "POST /account/register", type: :request do
   end
 
   context "with signed in user" do
-    it "redirects" do
+    before do
       user = Fixtures::Account.user
       env "rack.session", {usi: user.id}
+    end
+
+    it "redirects" do
       get url
       expect(last_response.status).to eq(302)
     end

--- a/spec/requests/account/settings/save_spec.rb
+++ b/spec/requests/account/settings/save_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe "POST /account/settings", type: :request do
   let(:url) { "/account/settings" }
 
   def perform_request(params = {})
-    default_params = { avatar: "", current_password: "", new_password: "", new_password_confirmation: "" }
+    default_params = {avatar: "", current_password: "", new_password: "", new_password_confirmation: ""}
     post url, default_params.merge(params)
   end
 
@@ -19,7 +19,7 @@ RSpec.describe "POST /account/settings", type: :request do
 
     before do
       Fixtures::Account.profile(user.id)
-      env "rack.session", { usi: user.id }
+      env "rack.session", {usi: user.id}
     end
 
     it "shows error when new passwords do not match" do
@@ -45,7 +45,7 @@ RSpec.describe "POST /account/settings", type: :request do
     it "does not update password when current password is incorrect" do
       perform_request current_password: "abcdefgh", new_password: "123123123", new_password_confirmation: "123123123"
       reloaded_user = Account::Repositories::Account.new.by_id(user.id)
-      expect(Argon2::Password.verify_password("123123123", user.password_hash)).to eq(false)
+      expect(Argon2::Password.verify_password("123123123", reloaded_user.password_hash)).to eq(false)
     end
 
     it "updates the password when correct params are passed" do

--- a/spec/requests/account/settings/save_spec.rb
+++ b/spec/requests/account/settings/save_spec.rb
@@ -1,0 +1,44 @@
+RSpec.describe "POST /account/settings", type: :request do
+  let(:url) { "/account/settings" }
+
+  context "as anonymous user" do
+    specify "redirect to home" do
+      post url, {}
+      expect(last_response.status).to eq(302)
+    end
+  end
+
+  context "as signed in user" do
+    let(:password) { "12345678" }
+    before do
+      user = Fixtures::Account.user(password:)
+      Fixtures::Account.profile(user.id)
+      env "rack.session", {usi: user.id}
+    end
+
+    it "shows error when new passwords do not match" do
+      params = {new_password: "123123123", new_password_confirmation: "124124124"}
+      post url, params
+      expect(last_response.body).to include("passwords do not match")
+    end
+
+    it "shows error when new password is too short" do
+      params = {new_password: "123", new_password_confirmation: "123"}
+      post url, params
+      expect(last_response.body).to include("size cannot be less than 8")
+    end
+
+    it "shows error when current password does not match" do
+      params = {current_password: SecureRandom.hex}
+      post url, params
+      expect(last_response.body).to include("incorrect password")
+    end
+
+    it "shows error when you provide new password but not current password (when new is valid)" do
+      params = {current_password: "", new_password: "123123123", new_password_confirmation: "123123123"}
+      post url, params
+      p last_response.body
+      expect(last_response.body).to include("incorrect password")
+    end
+  end
+end

--- a/spec/requests/account/settings/save_spec.rb
+++ b/spec/requests/account/settings/save_spec.rb
@@ -53,5 +53,14 @@ RSpec.describe "POST /account/settings", type: :request do
       reloaded_user = Account::Repositories::Account.new.by_id(user.id)
       expect(Argon2::Password.verify_password("123123123", reloaded_user.password_hash)).to eq(true)
     end
+
+    it "updates the avatar in the profile" do
+      file_path = File.join(Hanami.app.root, "spec", "support", "files", "cat_small.jpg")
+      perform_request avatar: Rack::Test::UploadedFile.new(file_path, "image/jpeg")
+      profile = Account::Repositories::Account.new.settings_for_user(user.id).profile
+      expect(profile.avatar_data).not_to be_nil
+      data = JSON.parse(profile.avatar_data)
+      expect(data["metadata"]["filename"]).to eq("cat_small.jpg")
+    end
   end
 end

--- a/spec/requests/account/settings/save_spec.rb
+++ b/spec/requests/account/settings/save_spec.rb
@@ -1,44 +1,57 @@
 RSpec.describe "POST /account/settings", type: :request do
   let(:url) { "/account/settings" }
 
+  def perform_request(params = {})
+    default_params = { avatar: "", current_password: "", new_password: "", new_password_confirmation: "" }
+    post url, default_params.merge(params)
+  end
+
   context "as anonymous user" do
     specify "redirect to home" do
-      post url, {}
+      perform_request
       expect(last_response.status).to eq(302)
     end
   end
 
   context "as signed in user" do
     let(:password) { "12345678" }
+    let(:user) { Fixtures::Account.user(password:) }
+
     before do
-      user = Fixtures::Account.user(password:)
       Fixtures::Account.profile(user.id)
-      env "rack.session", {usi: user.id}
+      env "rack.session", { usi: user.id }
     end
 
     it "shows error when new passwords do not match" do
-      params = {new_password: "123123123", new_password_confirmation: "124124124"}
-      post url, params
+      perform_request new_password: "123123123", new_password_confirmation: "124124124"
       expect(last_response.body).to include("passwords do not match")
     end
 
     it "shows error when new password is too short" do
-      params = {new_password: "123", new_password_confirmation: "123"}
-      post url, params
+      perform_request new_password: "123", new_password_confirmation: "123"
       expect(last_response.body).to include("size cannot be less than 8")
     end
 
     it "shows error when current password does not match" do
-      params = {current_password: SecureRandom.hex}
-      post url, params
+      perform_request current_password: SecureRandom.hex
       expect(last_response.body).to include("incorrect password")
     end
 
     it "shows error when you provide new password but not current password (when new is valid)" do
-      params = {current_password: "", new_password: "123123123", new_password_confirmation: "123123123"}
-      post url, params
-      p last_response.body
+      perform_request current_password: "", new_password: "123123123", new_password_confirmation: "123123123"
       expect(last_response.body).to include("incorrect password")
+    end
+
+    it "does not update password when current password is incorrect" do
+      perform_request current_password: "abcdefgh", new_password: "123123123", new_password_confirmation: "123123123"
+      reloaded_user = Account::Repositories::Account.new.by_id(user.id)
+      expect(Argon2::Password.verify_password("123123123", user.password_hash)).to eq(false)
+    end
+
+    it "updates the password when correct params are passed" do
+      perform_request current_password: password, new_password: "123123123", new_password_confirmation: "123123123"
+      reloaded_user = Account::Repositories::Account.new.by_id(user.id)
+      expect(Argon2::Password.verify_password("123123123", reloaded_user.password_hash)).to eq(true)
     end
   end
 end

--- a/spec/support/fixtures/account.rb
+++ b/spec/support/fixtures/account.rb
@@ -2,9 +2,15 @@ module Fixtures
   module Account
     extend self
 
-    def user
+    def user(password: SecureRandom.hex(10))
       ::Account::Container["commands.register_user"]
-        .call("#{SecureRandom.hex(16)}@test.com", "123123123")
+        .call("#{SecureRandom.hex(16)}@test.com", password)
+        .value!
+    end
+
+    def profile(user_id = nil)
+      ::Discussion::Container["commands.create_profile"]
+        .call(nickname: "Tester", account_id: user_id)
         .value!
     end
 


### PR DESCRIPTION
In general, this PR adds a new account settings page in the `accounts` slice. It supports avatar changing (which was up until now handled by the `discussion` slice - pending removal). It also adds password changing functionality.

![screenshot-localhost_2300-2023 09 20-00_26_26](https://github.com/katafrakt/palaver/assets/119904/8c1c3686-fc14-4217-98b7-008c451108e0)

On the way
* Introduces some cleanup in for components - pending further cleanup
* Introduces usage of do monad
* Creates a controller action that combines a few commands

In general, current direction is to move whole management of the profile to `accounts` slice and `discussion` would only read it.