### PR TITLE
Extract thread page as a separate query

### DIFF
--- a/slices/discussion/actions/thread/show.rb
+++ b/slices/discussion/actions/thread/show.rb
@@ -3,14 +3,15 @@
 class Discussion::Actions::Thread::Show < Discussion::Action
   include Discussion::Deps[
     repo: "repositories.thread",
-    slugger: "utils.slugger"
+    slugger: "utils.slugger",
+    query: "queries.thread_messages_page"
           ]
 
   def handle(req, res)
     id = slugger.decode_id(req.params[:id])
     page = req.params[:page] || 1
-    thread = repo.get(id)
-    pager = repo.paged_messages(thread.id, page.to_i)
-    res.render(Discussion::Templates::Thread::Show, thread:, pager:)
+    result = query.call(id, page)
+
+    res.render(Discussion::Templates::Thread::Show, thread: result[:thread], pager: result[:pager])
   end
 end

--- a/slices/discussion/entities/message.rb
+++ b/slices/discussion/entities/message.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+class Discussion::Entities::Message < Dry::Struct
+  class Author < Dry::Struct
+    include Palaver::Types
+    include Palaver::AvatarUploader::Attachment(:avatar)
+
+    attribute :nickname, String
+    attribute :id, Integer
+    attribute :message_count, Integer
+    attribute :avatar_data, String.optional
+  end
+
+  include Palaver::Types
+
+  attribute :id, Integer
+  attribute :text, String
+  attribute :posted_at, Time
+  attribute :author, Author
+
+  def self.from_rom(record)
+    author = Author.new(record.author.to_h)
+    new(record.to_h.merge(author: author))
+  end
+end

--- a/slices/discussion/queries/thread_messages_page.rb
+++ b/slices/discussion/queries/thread_messages_page.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+class Discussion::Queries::ThreadMessagesPage
+  include Discussion::Deps[repo: "repositories.thread"]
+
+  Pager = Struct.new(:entries, :total_entries, :total_pages, :current_page)
+
+  def call(thread_id, page_no)
+    thread = repo.get(thread_id)
+    thread = Discussion::Entities::Thread.new(thread.to_h)
+    all_thread_messages_count = repo.message_counts([thread_id]).first.count
+    entries = repo.paged_messages(thread_id, page_no.to_i)
+    entries.map! { |e| Discussion::Entities::Message.from_rom(e) }
+    pager = Pager.new(entries, all_thread_messages_count, (all_thread_messages_count / 15.0).ceil, page_no)
+
+    {thread:, pager:}
+  end
+end

--- a/slices/discussion/repositories/thread.rb
+++ b/slices/discussion/repositories/thread.rb
@@ -1,9 +1,6 @@
 module Discussion
   module Repositories
     class Thread < Palaver::Repository[:threads]
-      Page = Struct.new(:entries, :total_entries, :total_pages, :current_page)
-
-      struct_namespace Discussion::Entities
       commands :create
 
       def set_first_message(thread:, message:)
@@ -40,17 +37,13 @@ module Discussion
       end
 
       def paged_messages(thread_id, page = 1)
-        entries =
-          messages
-            .where(thread_id:)
-            .combine(:author)
-            .order(:posted_at)
-            .per_page(15)
-            .page(page)
-            .to_a
-
-        all_messages = messages.where(thread_id:).count
-        Page.new(entries, all_messages, (all_messages / 15.0).ceil, page)
+        messages
+          .where(thread_id:)
+          .combine(:author)
+          .order(:posted_at)
+          .per_page(15)
+          .page(page)
+          .to_a
       end
 
       def create_message(thread:, author:, content:)


### PR DESCRIPTION
`Discussion` slice is a bit messy right now, but entangled in a way that makes it difficult to move forward.
As a prep work to clean up the slice, this extracts a query fetching all necessary data to display a thread page into a separate query-class. Also adds some entities, some of them might be temporary.