### PR TITLE
Templates to views

### DIFF
--- a/config/app.rb
+++ b/config/app.rb
@@ -4,11 +4,23 @@ require "hanami"
 require "hanami/middleware/body_parser"
 
 module Palaver
+  # By default Hanami tries to find a matching class for current action,
+  # infer its name and instantiate it. However, this does not work with Phlex
+  # views. Hanami tries to create new instance with no arguments, but Phlex views
+  # use arguments in initialization. Therefore we need to disable this feature by
+  # creating a fake inferrer that always return empty array.
+  class FakeViewNameInferrer
+    def self.call(action_class_name:, slice:) = []
+  end
+
   class App < Hanami::App
     config.actions.content_security_policy[:default_src] = "*"
     config.actions.content_security_policy[:style_src] = "*"
     config.actions.content_security_policy[:script_src] = "*"
     config.actions.sessions = :cookie, {secret: ENV["SECRET"]}
     config.middleware.use Hanami::Middleware::BodyParser, :form
+
+    # disable default view inferrer
+    config.actions.view_name_inferrer = FakeViewNameInferrer
   end
 end

--- a/slices/account/actions/registration/create.rb
+++ b/slices/account/actions/registration/create.rb
@@ -18,15 +18,15 @@ class Account::Actions::Registration::Create < Account::Action
   end
 
   def handle(req, res)
-    render_on_invalid_params(res, Account::Templates::Registration::New)
+    render_on_invalid_params(res, Account::Views::Registration::New)
 
     case register_user.call(req.params[:email], req.params[:password])
     in Success(account)
-      res.render(Account::Templates::Registration::AfterCreate, account:)
+      res.render(Account::Views::Registration::AfterCreate, account:)
     else
       email_error = "must be unique"
       res.status = 422
-      res.render(Account::Templates::Registration::New, values: req.params.to_h, errors: {email: [email_error]})
+      res.render(Account::Views::Registration::New, values: req.params.to_h, errors: {email: [email_error]})
     end
   end
 end

--- a/slices/account/actions/registration/new.rb
+++ b/slices/account/actions/registration/new.rb
@@ -4,6 +4,6 @@ class Account::Actions::Registration::New < Account::Action
   require_signed_out_user!
 
   def handle(req, res)
-    res.render(Account::Templates::Registration::New, values: {}, errors: {})
+    res.render(Account::Views::Registration::New, values: {}, errors: {})
   end
 end

--- a/slices/account/actions/settings/save.rb
+++ b/slices/account/actions/settings/save.rb
@@ -52,7 +52,7 @@ class Account::Actions::Settings::Save < Account::Action
   def render_show(req, res)
     current_user = res[:current_user]
     settings = fetch_settings.call(current_user.id)
-    res.render(Account::Templates::Settings::Show, settings:, errors: req.params.errors, values: req.params.to_h)
+    res.render(Account::Views::Settings::Show, settings:, errors: req.params.errors, values: req.params.to_h)
   end
 
   def verify_current_password(account, req)

--- a/slices/account/actions/settings/show.rb
+++ b/slices/account/actions/settings/show.rb
@@ -7,6 +7,6 @@ class Account::Actions::Settings::Show < Account::Action
 
   def handle(req, res)
     settings = fetch_settings.call(res[:current_user].id)
-    res.render(Account::Templates::Settings::Show, settings:, errors: {}, values: {})
+    res.render(Account::Views::Settings::Show, settings:, errors: {}, values: {})
   end
 end

--- a/slices/account/actions/sign_in/create.rb
+++ b/slices/account/actions/sign_in/create.rb
@@ -11,7 +11,7 @@ class Account::Actions::SignIn::Create < Account::Action
   end
 
   def handle(req, res)
-    render_on_invalid_params(res, Account::Templates::SignIn::New)
+    render_on_invalid_params(res, Account::Views::SignIn::New)
 
     case sign_in.call(req.params[:email], req.params[:password])
     in Success(user)

--- a/slices/account/actions/sign_in/new.rb
+++ b/slices/account/actions/sign_in/new.rb
@@ -4,6 +4,6 @@ class Account::Actions::SignIn::New < Account::Action
   require_signed_out_user!
 
   def handle(req, res)
-    res.render(Account::Templates::SignIn::New, values: {}, errors: {})
+    res.render(Account::Views::SignIn::New, values: {}, errors: {})
   end
 end

--- a/slices/account/views/registration/after_create.rb
+++ b/slices/account/views/registration/after_create.rb
@@ -1,4 +1,4 @@
-class Account::Templates::Registration::AfterCreate < Palaver::View
+class Account::Views::Registration::AfterCreate < Palaver::View
   include Ui::Typography
 
   def template

--- a/slices/account/views/registration/new.rb
+++ b/slices/account/views/registration/new.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class Account::Templates::Registration::New < Palaver::View
+class Account::Views::Registration::New < Palaver::View
   include Ui::Typography
   include Ui::Form
 

--- a/slices/account/views/settings/show.rb
+++ b/slices/account/views/settings/show.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class Account::Templates::Settings::Show < Palaver::View
+class Account::Views::Settings::Show < Palaver::View
   include Ui::Typography
 
   def template

--- a/slices/account/views/sign_in/new.rb
+++ b/slices/account/views/sign_in/new.rb
@@ -2,7 +2,7 @@
 
 require "ui/typography"
 
-class Account::Templates::SignIn::New < Palaver::View
+class Account::Views::SignIn::New < Palaver::View
   include ::Ui::Typography
   include ::Ui::Form
 

--- a/slices/discussion/actions/category/show.rb
+++ b/slices/discussion/actions/category/show.rb
@@ -11,6 +11,6 @@ class Discussion::Actions::Category::Show < Discussion::Action
     id = slugger.decode_id(req.params[:id])
     category = repo.get(id)
     threads = query.call(category.id)
-    res.render(Discussion::Templates::Category::Show, category: category, threads: threads)
+    res.render(Discussion::Views::Category::Show, category: category, threads: threads)
   end
 end

--- a/slices/discussion/actions/home/index.rb
+++ b/slices/discussion/actions/home/index.rb
@@ -4,6 +4,6 @@ class Discussion::Actions::Home::Index < Discussion::Action
   include Discussion::Deps[query: "queries.homepage_categories"]
 
   def handle(_req, res)
-    res.render(Discussion::Templates::Home::Index, categories: query.call)
+    res.render(Discussion::Views::Home::Index, categories: query.call)
   end
 end

--- a/slices/discussion/actions/home/new_threads.rb
+++ b/slices/discussion/actions/home/new_threads.rb
@@ -4,6 +4,6 @@ class Discussion::Actions::Home::NewThreads < Discussion::Action
   include Discussion::Deps[query: "queries.homepage_new_threads"]
 
   def handle(_req, res)
-    res.render(Discussion::Templates::Home::NewThreads, threads: query.call)
+    res.render(Discussion::Views::Home::NewThreads, threads: query.call)
   end
 end

--- a/slices/discussion/actions/home/recent.rb
+++ b/slices/discussion/actions/home/recent.rb
@@ -4,6 +4,6 @@ class Discussion::Actions::Home::Recent < Discussion::Action
   include Discussion::Deps[query: "queries.homepage_recent"]
 
   def handle(_req, res)
-    res.render(Discussion::Templates::Home::Recent, threads: query.call)
+    res.render(Discussion::Views::Home::Recent, threads: query.call)
   end
 end

--- a/slices/discussion/actions/profile/show.rb
+++ b/slices/discussion/actions/profile/show.rb
@@ -9,6 +9,6 @@ class Discussion::Actions::Profile::Show < Discussion::Action
 
   def handle(req, res)
     profile = repo.from_current_user(res[:current_user])
-    res.render(Discussion::Templates::Profile::Show, profile:)
+    res.render(Discussion::Views::Profile::Show, profile:)
   end
 end

--- a/slices/discussion/actions/thread/show.rb
+++ b/slices/discussion/actions/thread/show.rb
@@ -5,7 +5,7 @@ class Discussion::Actions::Thread::Show < Discussion::Action
     repo: "repositories.thread",
     slugger: "utils.slugger",
     query: "queries.thread_messages_page"
-          ]
+  ]
 
   def handle(req, res)
     id = slugger.decode_id(req.params[:id])

--- a/slices/discussion/actions/thread/show.rb
+++ b/slices/discussion/actions/thread/show.rb
@@ -12,6 +12,6 @@ class Discussion::Actions::Thread::Show < Discussion::Action
     page = req.params[:page] || 1
     result = query.call(id, page)
 
-    res.render(Discussion::Templates::Thread::Show, thread: result[:thread], pager: result[:pager])
+    res.render(Discussion::Views::Thread::Show, thread: result[:thread], pager: result[:pager])
   end
 end

--- a/slices/discussion/views/category/show.rb
+++ b/slices/discussion/views/category/show.rb
@@ -7,7 +7,7 @@ class Discussion::Views::Category::Show < Palaver::View
         p { "No threads" }
       else
         @threads.each do |thread|
-          render Discussion::Components::ThreadRow.new(thread)
+          render Discussion::Views::Shared::Partials::ThreadRow.new(thread)
         end
       end
     end

--- a/slices/discussion/views/category/show.rb
+++ b/slices/discussion/views/category/show.rb
@@ -1,4 +1,4 @@
-class Discussion::Templates::Category::Show < Palaver::View
+class Discussion::Views::Category::Show < Palaver::View
   def template
     div do
       h2(class: "is-size-2") { @category.name }

--- a/slices/discussion/views/home/components/tabs.rb
+++ b/slices/discussion/views/home/components/tabs.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class Discussion::Components::HomeTabs < Phlex::HTML
+class Discussion::Views::Home::Components::Tabs < Phlex::HTML
   attr_reader :selected
 
   def initialize(selected)

--- a/slices/discussion/views/home/index.rb
+++ b/slices/discussion/views/home/index.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class Discussion::Templates::Home::Index < Palaver::View
+class Discussion::Views::Home::Index < Palaver::View
   def template
     div do
       render Discussion::Components::NoProfileWarning.new(current_user)

--- a/slices/discussion/views/home/index.rb
+++ b/slices/discussion/views/home/index.rb
@@ -3,12 +3,12 @@
 class Discussion::Views::Home::Index < Palaver::View
   def template
     div do
-      render Discussion::Components::NoProfileWarning.new(current_user)
-      render Discussion::Components::HomeTabs.new(:categories)
+      render Discussion::Views::Shared::Components::NoProfileWarning.new(current_user)
+      render Discussion::Views::Home::Components::Tabs.new(:categories)
 
       div(class: "section") do
         @categories.each do |category|
-          render Discussion::Components::CategoryRow.new(category: category)
+          render Discussion::Views::Home::Partials::Category.new(category: category)
         end
       end
     end

--- a/slices/discussion/views/home/new_threads.rb
+++ b/slices/discussion/views/home/new_threads.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 
-class Discussion::Templates::Home::Recent < Palaver::View
+class Discussion::Views::Home::NewThreads < Palaver::View
   def template
     div do
       render Discussion::Components::NoProfileWarning.new(current_user)
-      render Discussion::Components::HomeTabs.new(:recent)
+      render Discussion::Components::HomeTabs.new(:new)
 
       div(class: "section") do
         @threads.each do |thread|

--- a/slices/discussion/views/home/new_threads.rb
+++ b/slices/discussion/views/home/new_threads.rb
@@ -3,12 +3,12 @@
 class Discussion::Views::Home::NewThreads < Palaver::View
   def template
     div do
-      render Discussion::Components::NoProfileWarning.new(current_user)
-      render Discussion::Components::HomeTabs.new(:new)
+      render Discussion::Views::Shared::Components::NoProfileWarning.new(current_user)
+      render Discussion::Views::Home::Components::Tabs.new(:new)
 
       div(class: "section") do
         @threads.each do |thread|
-          render Discussion::Components::ThreadRow.new(thread)
+          render Discussion::Views::Shared::Partials::ThreadRow.new(thread)
         end
       end
     end

--- a/slices/discussion/views/home/partials/category.rb
+++ b/slices/discussion/views/home/partials/category.rb
@@ -1,4 +1,4 @@
-class Discussion::Components::CategoryRow < Phlex::HTML
+class Discussion::Views::Home::Partials::Category < Phlex::HTML
   include Discussion::Deps["utils.slugger"]
 
   class Detail < Phlex::HTML

--- a/slices/discussion/views/home/recent.rb
+++ b/slices/discussion/views/home/recent.rb
@@ -3,12 +3,12 @@
 class Discussion::Views::Home::Recent < Palaver::View
   def template
     div do
-      render Discussion::Components::NoProfileWarning.new(current_user)
-      render Discussion::Components::HomeTabs.new(:recent)
+      render Discussion::Views::Shared::Components::NoProfileWarning.new(current_user)
+      render Discussion::Views::Home::Components::Tabs.new(:recent)
 
       div(class: "section") do
         @threads.each do |thread|
-          render Discussion::Components::ThreadRow.new(thread)
+          render Discussion::Views::Shared::Partials::ThreadRow.new(thread)
         end
       end
     end

--- a/slices/discussion/views/home/recent.rb
+++ b/slices/discussion/views/home/recent.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 
-class Discussion::Templates::Home::NewThreads < Palaver::View
+class Discussion::Views::Home::Recent < Palaver::View
   def template
     div do
       render Discussion::Components::NoProfileWarning.new(current_user)
-      render Discussion::Components::HomeTabs.new(:new)
+      render Discussion::Components::HomeTabs.new(:recent)
 
       div(class: "section") do
         @threads.each do |thread|

--- a/slices/discussion/views/profile/show.rb
+++ b/slices/discussion/views/profile/show.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class Discussion::Templates::Profile::Show < Palaver::View
+class Discussion::Views::Profile::Show < Palaver::View
   include Ui::Typography
 
   def template

--- a/slices/discussion/views/shared/components/no_profile_warning.rb
+++ b/slices/discussion/views/shared/components/no_profile_warning.rb
@@ -1,4 +1,6 @@
-class Discussion::Components::NoProfileWarning < Phlex::HTML
+# frozen_string_literal: true
+
+class Discussion::Views::Shared::Components::NoProfileWarning < Phlex::HTML
   def initialize(current_user)
     @current_user = current_user
   end

--- a/slices/discussion/views/shared/partials/thread_row.rb
+++ b/slices/discussion/views/shared/partials/thread_row.rb
@@ -1,4 +1,6 @@
-class Discussion::Components::ThreadRow < Phlex::HTML
+# frozen_string_literal: true
+
+class Discussion::Views::Shared::Partials::ThreadRow < Phlex::HTML
   include Discussion::Deps["utils.slugger"]
 
   def initialize(thread, slugger:)

--- a/slices/discussion/views/thread/show.rb
+++ b/slices/discussion/views/thread/show.rb
@@ -1,4 +1,4 @@
-class Discussion::Templates::Thread::Show < Palaver::View
+class Discussion::Views::Thread::Show < Palaver::View
   include Ui::Typography
   include Ui::Form
   include Discussion::Deps[

--- a/slices/discussion/views/thread/show.rb
+++ b/slices/discussion/views/thread/show.rb
@@ -17,7 +17,7 @@ class Discussion::Views::Thread::Show < Palaver::View
       if access_control.authorizer.authorized?(current_user, @thread, :reply)
         reply_form
       else
-        render Discussion::Components::NoProfileWarning.new(current_user)
+        render Discussion::Views::Shared::Components::NoProfileWarning.new(current_user)
       end
 
       pagination

--- a/spec/slices/discussion/views/home/partials/category_spec.rb
+++ b/spec/slices/discussion/views/home/partials/category_spec.rb
@@ -1,6 +1,6 @@
 require "nokolexbor"
 
-RSpec.describe Discussion::Components::CategoryRow do
+RSpec.describe Discussion::Views::Home::Partials::Category do
   include Phlex::Testing::ViewHelper
 
   let(:category) { Discussion::Entities::Category.new(name: "Announcements", id: 24, thread_count: 25, message_count: 67) }

--- a/spec/slices/discussion/views/shared/components/no_profile_warning_spec.rb
+++ b/spec/slices/discussion/views/shared/components/no_profile_warning_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe Discussion::Components::NoProfileWarning do
+RSpec.describe Discussion::Views::Shared::Components::NoProfileWarning do
   include Phlex::Testing::ViewHelper
 
   let(:anonymous_user) { Discussion::Entities::CurrentUser.new }

--- a/spec/slices/discussion/views/shared/partials/thread_row_spec.rb
+++ b/spec/slices/discussion/views/shared/partials/thread_row_spec.rb
@@ -1,6 +1,6 @@
 require "nokolexbor"
 
-RSpec.describe Discussion::Components::ThreadRow do
+RSpec.describe Discussion::Views::Shared::Partials::ThreadRow do
   include Phlex::Testing::ViewHelper
 
   let(:thread) { Discussion::Entities::Thread.new(title: "Registrations are now closed", id: 22, message_count: 1, pinned: false, messages: []) }


### PR DESCRIPTION
For historical reason views were called templates. Also, `components` was a directory under slice root. This changes templates naming to views (closer to what Phlex is) and puts components and partials under `views` directory.

This also needs to disable default Hanami's view name inferrer. Even though `hanami-view` is not added, Hanami tries to resolve views to classes and then fails to initialize them (dry-system deps usually have no args to initializer, whiile Phlex views have them).