### PR TITLE
Don't show reply form unless we are on the last page

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,0 +1,4 @@
+DATABASE_URL=postgres://postgres@localhost/palaver_dev
+SECRET=fc4nuaouxn4oau4cc4achiuc3haiAC-catiu4ach
+HASHIDS_SALT=this_is_the_salt
+DEFAULT_MESSAGES_PER_THREAD_PAGE=15

--- a/.env.test
+++ b/.env.test
@@ -1,3 +1,4 @@
 DATABASE_URL=postgres://postgres@localhost/palaver_test
 SECRET=test
 HASHIDS_SALT=this_is_the_salt
+DEFAULT_MESSAGES_PER_THREAD_PAGE=3

--- a/slices/discussion/queries/thread_messages_page.rb
+++ b/slices/discussion/queries/thread_messages_page.rb
@@ -6,12 +6,13 @@ class Discussion::Queries::ThreadMessagesPage
   Pager = Struct.new(:entries, :total_entries, :total_pages, :current_page)
 
   def call(thread_id, page_no)
+    messages_per_page = ENV["DEFAULT_MESSAGES_PER_THREAD_PAGE"] || 15
     thread = repo.get(thread_id)
     thread = Discussion::Entities::Thread.new(thread.to_h)
     all_thread_messages_count = repo.message_counts([thread_id]).first.count
     entries = repo.paged_messages(thread_id, page_no.to_i)
     entries.map! { |e| Discussion::Entities::Message.from_rom(e) }
-    pager = Pager.new(entries, all_thread_messages_count, (all_thread_messages_count / 15.0).ceil, page_no.to_i)
+    pager = Pager.new(entries, all_thread_messages_count, (all_thread_messages_count / messages_per_page.to_f).ceil, page_no.to_i)
 
     {thread:, pager:}
   end

--- a/slices/discussion/views/thread/show.rb
+++ b/slices/discussion/views/thread/show.rb
@@ -14,13 +14,21 @@ class Discussion::Views::Thread::Show < Palaver::View
         message_row(message)
       end
 
-      if access_control.authorizer.authorized?(current_user, @thread, :reply)
+      if @pager.current_page < @pager.total_pages
+        article(class: "message is-warning") do
+          div(class: "message-body") do
+            plain "This is not the end of the thread. Go to the "
+            a(href: "?page=#{@pager.total_pages}") { "last page" }
+            plain " to reply."
+          end
+        end
+      elsif access_control.authorizer.authorized?(current_user, @thread, :reply)
         reply_form
       else
         render Discussion::Views::Shared::Components::NoProfileWarning.new(current_user)
       end
 
-      pagination
+      pagination if @pager.total_pages > 1
     end
   end
 


### PR DESCRIPTION
Simple improvement hiding a reply form if we are on a non-last page of the thread.